### PR TITLE
GH-1 Upgrading for compatibility with SpringBoot 2.1.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <springboot.version>2.1.1.RELEASE</springboot.version>
+        <springboot.version>2.1.3.RELEASE</springboot.version>
     </properties>
 
     <scm>

--- a/spring-multirabbit-examples/spring-multirabbit-example-java/pom.xml
+++ b/spring-multirabbit-examples/spring-multirabbit-example-java/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.1.1.RELEASE</version>
+        <version>2.1.3.RELEASE</version>
         <relativePath />
     </parent>
 

--- a/spring-multirabbit-examples/spring-multirabbit-example-kotlin/pom.xml
+++ b/spring-multirabbit-examples/spring-multirabbit-example-kotlin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.1.1.RELEASE</version>
+        <version>2.1.3.RELEASE</version>
         <relativePath />
     </parent>
 

--- a/spring-multirabbit-examples/spring-multirabbit-extension-example/pom.xml
+++ b/spring-multirabbit-examples/spring-multirabbit-extension-example/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.1.1.RELEASE</version>
+        <version>2.1.3.RELEASE</version>
         <relativePath />
     </parent>
 

--- a/spring-multirabbit-lib-integration/pom.xml
+++ b/spring-multirabbit-lib-integration/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.1.1.RELEASE</version>
+        <version>2.1.3.RELEASE</version>
         <relativePath />
     </parent>
 

--- a/spring-multirabbit-lib/pom.xml
+++ b/spring-multirabbit-lib/pom.xml
@@ -20,7 +20,7 @@
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
-                <version>2.1.1.RELEASE</version>
+                <version>2.1.3.RELEASE</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
The latest version (SpringBoot 2.1.4) is not working with the library: GH-2.
This PR is to ensure compatibility until 2.1.3.