### PR TITLE
GH-1 Upgrading for compatibility with SpringBoot 2.0.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <springboot.version>2.0.0.RELEASE</springboot.version>
+        <springboot.version>2.0.9.RELEASE</springboot.version>
     </properties>
 
     <scm>

--- a/spring-multirabbit-examples/spring-multirabbit-example-java/pom.xml
+++ b/spring-multirabbit-examples/spring-multirabbit-example-java/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.0.0.RELEASE</version>
+        <version>2.0.9.RELEASE</version>
         <relativePath />
     </parent>
 

--- a/spring-multirabbit-examples/spring-multirabbit-example-kotlin/pom.xml
+++ b/spring-multirabbit-examples/spring-multirabbit-example-kotlin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.0.0.RELEASE</version>
+        <version>2.0.9.RELEASE</version>
         <relativePath />
     </parent>
 

--- a/spring-multirabbit-examples/spring-multirabbit-extension-example/pom.xml
+++ b/spring-multirabbit-examples/spring-multirabbit-extension-example/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.0.0.RELEASE</version>
+        <version>2.0.9.RELEASE</version>
         <relativePath />
     </parent>
 

--- a/spring-multirabbit-lib-integration/pom.xml
+++ b/spring-multirabbit-lib-integration/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.0.0.RELEASE</version>
+        <version>2.0.9.RELEASE</version>
         <relativePath />
     </parent>
 

--- a/spring-multirabbit-lib/pom.xml
+++ b/spring-multirabbit-lib/pom.xml
@@ -20,7 +20,7 @@
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
-                <version>2.0.0.RELEASE</version>
+                <version>2.0.9.RELEASE</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/spring-multirabbit-lib/src/main/java/org/springframework/boot/autoconfigure/amqp/MultiRabbitAutoConfiguration.java
+++ b/spring-multirabbit-lib/src/main/java/org/springframework/boot/autoconfigure/amqp/MultiRabbitAutoConfiguration.java
@@ -15,11 +15,13 @@ import org.springframework.amqp.rabbit.config.RabbitListenerConfigUtils;
 import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.connection.ConnectionNameStrategy;
 import org.springframework.amqp.rabbit.connection.SimpleRoutingConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitAdmin;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -89,11 +91,15 @@ public class MultiRabbitAutoConfiguration
         private ConfigurableListableBeanFactory beanFactory;
         private ApplicationContext applicationContext;
         private final RabbitAutoConfiguration.RabbitConnectionFactoryCreator springFactoryCreator;
+        private final ObjectProvider<ConnectionNameStrategy> connectionNameStrategy;
 
 
-        MultiRabbitConnectionFactoryCreator(RabbitAutoConfiguration.RabbitConnectionFactoryCreator springFactoryCreator)
+        MultiRabbitConnectionFactoryCreator(
+            RabbitAutoConfiguration.RabbitConnectionFactoryCreator springFactoryCreator,
+            ObjectProvider<ConnectionNameStrategy> connectionNameStrategy)
         {
             this.springFactoryCreator = springFactoryCreator;
+            this.connectionNameStrategy = connectionNameStrategy;
         }
 
 
@@ -196,7 +202,7 @@ public class MultiRabbitAutoConfiguration
         {
             try
             {
-                return springFactoryCreator.rabbitConnectionFactory(rabbitProperties);
+                return springFactoryCreator.rabbitConnectionFactory(rabbitProperties, connectionNameStrategy);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
This PR is to ensure compatibility until 2.0.9.
This release was branched previously from 2.1.x, in order to keep some history and compatibility when compared with the other releases.